### PR TITLE
[PKO-235] Remove `package-operator-webhook` component mentions

### DIFF
--- a/content/en/docs/getting_started/architecture.md
+++ b/content/en/docs/getting_started/architecture.md
@@ -16,13 +16,6 @@ Package Operator Manager also contains functionality to allow
 Package Operator to bootstrap itself, which is discussed
 on the [Installation Page](/docs/getting_started/installation#via_package_operator).
 
-## Webhooks
-
-There is a validation webhook server that can optionally be run with package operator.
-This webhook server verifies the immutability of certain fields of `ObjectSet`
-and `ObjectSetPhase` resources. If one of these immutable fields is changed in
-an update, the webhook server will disallow the update.
-
 ## Loading Package Images
 
 A package is a single artifact that contains all manifests, configuration,

--- a/content/en/docs/getting_started/installation.md
+++ b/content/en/docs/getting_started/installation.md
@@ -16,8 +16,6 @@ Package Operator is able to bootstrap and upgrade itself using a special self-bo
 Make sure `KUBECONFIG` is defined and the config points at your Kubernetes cluster.
 Then you can deploy Package Operator to bootstrap itself.
 
-Note: Both these command will not install the webhook server.
-
 ### Using `kubectl` cli
 
 ```sh


### PR DESCRIPTION
The `package-operator-webhook` component was removed by [#1809](https://github.com/package-operator/package-operator/pull/1809). This PR removes all mentions of the component from the documentation.

Jira: [PKO-235](https://issues.redhat.com/browse/PKO-235)